### PR TITLE
Fix queue processing bug in transcript downloader

### DIFF
--- a/08-building-search-applications/scripts/transcript_download.py
+++ b/08-building-search-applications/scripts/transcript_download.py
@@ -114,9 +114,12 @@ def get_transcript(playlist_item, counter_id):
 
 
 def process_queue():
-    """process the queue"""
-    while not q.empty():
-        video = q.get()
+    """Process the queue until it is empty."""
+    while True:
+        try:
+            video = q.get_nowait()
+        except queue.Empty:
+            break
 
         counter.increment()
 


### PR DESCRIPTION
## Summary
- fix hang on empty queue in `transcript_download.py`

## Testing
- `python -m py_compile 08-building-search-applications/scripts/transcript_download.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa58efc24832b886acd2a2bbe90e3