### PR TITLE
Add English vocabulary memorization project

### DIFF
--- a/english-vocab-app/README.md
+++ b/english-vocab-app/README.md
@@ -1,0 +1,21 @@
+# English Vocabulary Memorization App
+
+This simple project provides a command-line tool to help you practice English vocabulary. It loads a small list of words and their definitions, quizzes you randomly and tracks your progress in the session.
+
+## Features
+
+- Random flash cards
+- Tracks how many answers you get correct
+- Easy to extend with your own vocabulary list
+
+## Usage
+
+```bash
+python app.py
+```
+
+During each run, the app will show a word in English and ask you for its translation in your native language. Type the correct answer and press Enter to see if you are right. The program will continue until you decide to quit with `Ctrl+C`.
+
+## Customizing Words
+
+Edit `words.json` to add or modify vocabulary. Each entry should contain an `english` word and its `translation` field.

--- a/english-vocab-app/app.py
+++ b/english-vocab-app/app.py
@@ -1,0 +1,36 @@
+import json
+import os
+import random
+
+
+def load_words(path="words.json"):
+    base = os.path.dirname(__file__)
+    file_path = os.path.join(base, path)
+    with open(file_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def quiz(words):
+    correct = 0
+    total = 0
+    try:
+        while True:
+            word = random.choice(words)
+            ans = input(f"Translate '{word['english']}': ").strip()
+            if ans.lower() == word['translation'].lower():
+                print("Correct!\n")
+                correct += 1
+            else:
+                print(f"Wrong, the answer is {word['translation']}.\n")
+            total += 1
+    except KeyboardInterrupt:
+        print(f"\nYou answered {correct} out of {total} correctly. Goodbye!")
+
+
+def main():
+    words = load_words()
+    quiz(words)
+
+
+if __name__ == "__main__":
+    main()

--- a/english-vocab-app/words.json
+++ b/english-vocab-app/words.json
@@ -1,0 +1,8 @@
+[
+  {"english": "apple", "translation": "苹果"},
+  {"english": "banana", "translation": "香蕉"},
+  {"english": "orange", "translation": "橙子"},
+  {"english": "grape", "translation": "葡萄"},
+  {"english": "watermelon", "translation": "西瓜"}
+]
+


### PR DESCRIPTION
## Summary
- add `english-vocab-app` folder
- include a simple command-line flash card program
- add sample vocabulary list and usage instructions

## Testing
- `python -m py_compile english-vocab-app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_683fa6567c9c832bab79233415903dd5